### PR TITLE
update xgboost with autogluon 0.2

### DIFF
--- a/tabular/setup.py
+++ b/tabular/setup.py
@@ -20,7 +20,7 @@ requirements = [
     'numpy>=1.19',
     'scipy',
     'catboost>=0.23.0,<0.25',
-    'xgboost>=1.2,<1.3',
+    'xgboost>=1.3.2,<1.4',
     'lightgbm>=3.0,<4.0',
     'pandas>=1.0.0,<2.0',
     'psutil>=5.0.0,<=5.7.0',  # TODO: psutil 5.7.1/5.7.2 has non-deterministic error on CI doc build -  ImportError: cannot import name '_psutil_linux' from 'psutil'


### PR DESCRIPTION
to fix cannot import name 'EarlyStopping' from 'xgboost.callback' https://github.com/Actable-AI/superset/issues/1405